### PR TITLE
Added back Z_SAFE_HOMING conditional

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1779,6 +1779,7 @@
   #endif
 #endif
 
+#if ENABLED(Z_SAFE_HOMING)
   #define Z_SAFE_HOMING_X_POINT Z_SAFE_X_POINT    // X point for Z homing when homing all axes (G28).
   #define Z_SAFE_HOMING_Y_POINT Z_SAFE_Y_POINT    // Y point for Z homing when homing all axes (G28).
 #endif


### PR DESCRIPTION
### Description

Added back the `#if ENABLED(Z_SAFE_HOMING)` that was probably removed by a mistake. Without it the code will not build as the `#endif` on line 1785 in Configuration.h is without a preceding `#if`.

### Benefits

The code can now built and the user is able to switch the Z_SAFE_HOMING option on

### Related Issues

None.